### PR TITLE
Add business image and anomaly modal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { BusinessCard } from './components/BusinessCard';
 import { AnomalyCard } from './components/AnomalyCard';
 import { AnomalyFormModal } from './components/AnomalyFormModal';
 import { AddBusinessModal } from './components/AddBusinessModal'; // Importa il nuovo modale
+import { BusinessDetailsModal } from './components/BusinessDetailsModal';
 import { BusinessMap } from './components/BusinessMap';
 import { Business, Anomaly } from './types';
 import { MOCK_BUSINESSES_DATA_KEY, MOCK_ANOMALIES_DATA_KEY } from './constants';
@@ -51,6 +52,7 @@ const App: React.FC = () => {
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [isAnomalyFormOpen, setIsAnomalyFormOpen] = useState(false);
   const [isAddBusinessModalOpen, setIsAddBusinessModalOpen] = useState(false); // Stato per il nuovo modale
+  const [isBusinessDetailsOpen, setIsBusinessDetailsOpen] = useState(false);
   const [isApiKeyAvailable, setIsApiKeyAvailable] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -69,6 +71,9 @@ const App: React.FC = () => {
   const handleSelectBusiness = (businessId: string) => {
     const business = businesses.find(b => b.id === businessId);
     setSelectedBusiness(business || null);
+    if (business) {
+      setIsBusinessDetailsOpen(true);
+    }
   };
 
   const handleAddAnomaly = (newAnomaly: Anomaly) => {
@@ -195,12 +200,21 @@ const App: React.FC = () => {
       <Footer />
 
       {selectedBusiness && (
-        <AnomalyFormModal 
+        <AnomalyFormModal
           isOpen={isAnomalyFormOpen}
           onClose={() => setIsAnomalyFormOpen(false)}
           business={selectedBusiness}
           onAddAnomaly={handleAddAnomaly}
           isApiKeyAvailable={isApiKeyAvailable}
+        />
+      )}
+
+      {selectedBusiness && (
+        <BusinessDetailsModal
+          isOpen={isBusinessDetailsOpen}
+          business={selectedBusiness}
+          anomalies={anomaliesForSelectedBusiness}
+          onClose={() => setIsBusinessDetailsOpen(false)}
         />
       )}
 

--- a/components/BusinessDetailsModal.tsx
+++ b/components/BusinessDetailsModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Business, Anomaly } from '../types';
+import { Modal } from './Modal';
+import { AnomalyCard } from './AnomalyCard';
+
+interface BusinessDetailsModalProps {
+  isOpen: boolean;
+  business: Business;
+  anomalies: Anomaly[];
+  onClose: () => void;
+}
+
+export const BusinessDetailsModal: React.FC<BusinessDetailsModalProps> = ({ isOpen, business, anomalies, onClose }) => {
+  if (!isOpen) return null;
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`Dettagli ${business.name}`} size="xl">
+      {business.photoBase64 && (
+        <div className="mb-4 flex justify-center">
+          <img src={business.photoBase64} alt={business.name} className="max-h-60 object-contain rounded-md border border-slate-700" />
+        </div>
+      )}
+      <div className="mb-4 space-y-1 text-sm text-slate-200">
+        <p><strong>Indirizzo:</strong> {business.address}</p>
+        <p><strong>Località:</strong> {business.location}</p>
+        {business.piva && <p><strong>P.IVA:</strong> {business.piva}</p>}
+        {typeof business.latitude === 'number' && typeof business.longitude === 'number' && (
+          <p><strong>Coordinate:</strong> {business.latitude}, {business.longitude}</p>
+        )}
+      </div>
+      <h3 className="text-lg font-semibold text-cyan-400 mb-2">Anomalie Segnalate ({anomalies.length})</h3>
+      <div className="space-y-3 max-h-96 overflow-y-auto pr-1">
+        {anomalies.length > 0 ? (
+          anomalies.map(anomaly => (
+            <AnomalyCard key={anomaly.id} anomaly={anomaly} />
+          ))
+        ) : (
+          <p className="text-slate-400">Nessuna anomalia per questa attività.</p>
+        )}
+      </div>
+    </Modal>
+  );
+};


### PR DESCRIPTION
## Summary
- show business details modal with image and anomalies
- open modal on business selection

## Testing
- `npm install` in `backend`
- `npm test` *(fails: ConnectionManager.getConnection was called after the connection manager was closed)*

------
https://chatgpt.com/codex/tasks/task_e_684df8d617b4832da686872d9756697d